### PR TITLE
Draft to fix compiler warnings for tests

### DIFF
--- a/.github/workflows/testing_and_building_repo.yml
+++ b/.github/workflows/testing_and_building_repo.yml
@@ -50,3 +50,11 @@ jobs:
           export DIST_FILE=$(ls bambi-*.tar.gz)
           export SHA256_FILE=$DIST_FILE.sha256
           shasum -a 256 $DIST_FILE > $SHA256_FILE
+
+    - name: Archive test logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-logs
+        path: test-suite.log
+        retention-days: 1

--- a/.github/workflows/testing_and_building_repo.yml
+++ b/.github/workflows/testing_and_building_repo.yml
@@ -18,6 +18,7 @@ jobs:
           # https://github.com/actions/runner-images/issues/2139
           sudo apt-get remove -y nginx libgd3
           sudo apt-get install -y libgd-dev liblzma-dev  libcurl4-openssl-dev
+          sudo apt-get install -y samtools
 
     - name: clone samtools branch
       run: |

--- a/test/t_read2tags.c
+++ b/test/t_read2tags.c
@@ -344,7 +344,11 @@ void checkFiles(char *gotfile, char *expectfile, int verbose)
     char expline[1024];
 
     while (fgets(getline, 1023, getfp) > 0) {
-        fgets(expline, 1023, expfp);
+        if ((fgets(expline, 1023, expfp)) == NULL) {
+            if (verbose) fprintf(stderr, "failed to read from expfp\n");
+            failure++;
+            break;
+        }
         if (strcmp(getline,expline) != 0) {
             fprintf(stderr, "Expected: %sFound   : %s\n", expline, getline);
             failure++;

--- a/test/t_read2tags.c
+++ b/test/t_read2tags.c
@@ -322,10 +322,21 @@ void checkFiles(char *gotfile, char *expectfile, int verbose)
     BAMit_free(bgot);
 
     char cmd[1024];
+    int result_got;
+    int result_exp;
     sprintf(cmd, "samtools view -o /tmp/got.sam %s ", gotfile);
-    system(cmd);
+    result_got = system(cmd);
+    if (result_got) {
+        if (verbose) fprintf(stderr, "execution of samtools view for /tmp/got.sam failed\n");
+        failure++;
+    }
+
     sprintf(cmd, "samtools view -o /tmp/exp.sam %s ", expectfile);
-    system(cmd);
+    result_exp = system(cmd);
+    if (result_exp) {
+        if (verbose) fprintf(stderr, "execution of samtools view for /tmp/exp.sam failed\n");
+        failure++;
+    }
 
     FILE *getfp = fopen("/tmp/got.sam", "r");
     FILE *expfp = fopen("/tmp/exp.sam", "r");


### PR DESCRIPTION
Leaving it as draft because I installed samtools using apt (which is a very old version of samtools). We may want to manually install a more modern version of samtools in the CI runner. But means we are adding the dependency on samtools for tests.